### PR TITLE
Repository struct should have description field...

### DIFF
--- a/parse-json/README.md
+++ b/parse-json/README.md
@@ -143,7 +143,7 @@ use hyper::header::{Headers, UserAgent};
 +#[derive(Deserialize, Debug)]
 +struct Repository {
 +    name: String,
-+    description: String,
++    description: Option<String>, // description is an Option<String> here, as it is optional field in github repos and might return null in JSON
 +    fork: bool,
 +}
 
@@ -196,10 +196,10 @@ Run it now and you should see this:
 ```bash
 $ cargo run -q
 Result is:
-[Repository { name: "ajv", description: "The fastest JSON schema Validator. Supports v5 proposals", fork: true }, Repository { name: "angular", description: "Code to optimize AngularJS for complex pages", fork: true }, ...]
+[Repository { name: "ajv", description: Some("The fastest JSON schema Validator. Supports v5 proposals"), fork: true }, Repository { name: "angular", description: Some("Code to optimize AngularJS for complex pages"), fork: true }, ...]
 ```
 
-You see that our `Vec<Repository>` is printed with `{:?}` in the format `[Repository { name, description, fork }, ...]`. Thanks to `#[derive(Debug)]`!
+You see that our `Vec<Repository>` is printed with `{:?}` in the format `[Repository { name, description, fork }, ...]`. Thanks to `#[derive(Debug)]`! Notice that `description` has a form of `Some(...)` - in the corresponding struct it was declared as an `Option<String>`, because the description field is optional and non-required on every github repo.
 
 But that is not all: The [string formatting](https://doc.rust-lang.org/nightly/std/fmt/index.html) in Rust allow you to do a bunch of really cool things, e.g., padding inputs to a certain length or choosing representations for numbers. One of the most amazing features is the "alternate mode", which you can trigger with an `#`. The alternate mode for `Debug` is to pretty-print the data, so it gets split up in lines and is nicely indented!
 
@@ -218,12 +218,16 @@ Result is:
 [
     Repository {
         name: "ajv",
-        description: "The fastest JSON schema Validator. Supports v5 proposals",
+        description: Some(
+          "The fastest JSON schema Validator. Supports v5 proposals"
+        ),
         fork: true
     },
     Repository {
         name: "angular",
-        description: "Code to optimize AngularJS for complex pages",
+        description: Some(
+          "Code to optimize AngularJS for complex pages"
+        ),
         fork: true
     },
     ...


### PR DESCRIPTION
...defined as` Option<String>`. Simply, because `description` is an optional field in github repos and might appear as `null` in JSON response.