### PR TITLE
Change all links to README.md rather than directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ I try to add an example every two weeks.
 
 # Table of contents
 
-0. [Setup](setup)
-0. [Hello World](hello-world)
-0. [Package Manager](package-manager)
-0. [Read files](read-files)
-0. [Write files](write-files)
-0. [HTTP requests](http-requests)
-0. [Parse JSON](parse-json)
+0. [Setup](setup/README.md)
+0. [Hello World](hello-world/README.md)
+0. [Package Manager](package-manager/README.md)
+0. [Read files](read-files/README.md)
+0. [Write files](write-files/README.md)
+0. [HTTP requests](http-requests/README.md)
+0. [Parse JSON](parse-json/README.md)
 
 Thank you for reading this article. ♥
 

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -44,4 +44,4 @@ Now you'll see `Hello world!` in your console. This shows a fundamental differen
 
 ______
 
-← [prev](../setup) | [next](../package-manager) →
+← [prev](../setup/README.md) | [next](../package-manager/README.md) →

--- a/http-requests/README.md
+++ b/http-requests/README.md
@@ -231,11 +231,11 @@ fn main() {
 }
 ```
 
-First we tell the compiler that we want to use an external crate called `hyper`. Than we import `std::io::Read` which you should know from our [_read files exampe_](../read-files) and we import `hyper::Client` which allows us to make requests.
+First we tell the compiler that we want to use an external crate called `hyper`. Than we import `std::io::Read` which you should know from our [_read files exampe_](../read-files/README.md) and we import `hyper::Client` which allows us to make requests.
 
 In our `main` function we set our `url` containing the protocol, host and path for our request. After that we create a new instance of the [`Client` struct](http://hyper.rs/hyper/0.8.0/hyper/client/struct.Client.html) which we call `client`. `client` has a `get` method which we can pass our `url` into. It will _not_ start the request immediately, but return an instance of the [`RequestBuilder` struct](http://hyper.rs/hyper/v0.9.10/hyper/client/struct.RequestBuilder.html). This one has a `send` method which will start the request. `send` returns `Result<Response>`, so we call `expect` to handle the `Error` case and get an instance of [`Response` struct](http://hyper.rs/hyper/0.8.0/hyper/client/response/struct.Response.html) as the result in the `Ok` case.
 
-After that we read our result into a buffer (`buf`) and print the response body. This should also be familiar from the [_read files exampe_](../read-files).
+After that we read our result into a buffer (`buf`) and print the response body. This should also be familiar from the [_read files exampe_](../read-files/README.md).
 
 If you run our program now you see the same error as in our first Node example:
 
@@ -340,4 +340,4 @@ The Node and the Rust example both show the same result now. Nice. In the next e
 
 ______
 
-← [prev](../write-files) | [next](../parse-json) →
+← [prev](../write-files/README.md) | [next](../parse-json/README.md) →

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -7,7 +7,7 @@ Node and Rust both come with a package manager. Node's package manager is called
 ![official npm website](./npm-site.png)
 ![official Cargo website](./cargo-site.png)
 
-If you followed my [Setup](../setup) and you use Node v4.4.5 you should update the bundled npm version, because it is relatively old by now. Node v4.4.5 comes with npm v2.15.5, but the current stable version is v3.9.5 at the time of writing this and v3 and v2 differ in a lot of ways. To update npm you just call this:
+If you followed my [Setup](../setup/README.md) and you use Node v4.4.5 you should update the bundled npm version, because it is relatively old by now. Node v4.4.5 comes with npm v2.15.5, but the current stable version is v3.9.5 at the time of writing this and v3 and v2 differ in a lot of ways. To update npm you just call this:
 
 ```bash
 $ npm install -g npm
@@ -265,7 +265,7 @@ As you can see this line of code in Rust is really similar to our TypeScript cod
 export const HELLO_WORLD: string = 'Hello world!';
 ```
 
-`pub` makes our `const` _public_ (much like `export` in JavaScript). Unlike TypeScript we _need_ to declare the type of `HELLO_WORLD` here or we'll get compiler errors. (Rust also supports type infering, but it looks like `const` always requires an [explicit type annotation](http://rustbyexample.com/custom_types/constants.html). Maybe this [could change in the future](https://users.rust-lang.org/t/when-i-export-a-str-as-const-why-do-i-need-to-set-its-type-and-lifetime/6112/2) for cases like this one.) [As noted earlier](../hello-world) `"Hello world!"` is called a _string literal_. Its type is `&str` (spoken as _string slice_). Rust actually has another String type called just `String`. A `&str` has a fixed size and cannot be mutated while a `String` is heap-allocated and has a dynamic size. A `&str` can be easily converted to a `String` with the `to_string` method like this: `"Hello world!".to_string();`. We'll see more of that in later examples.
+`pub` makes our `const` _public_ (much like `export` in JavaScript). Unlike TypeScript we _need_ to declare the type of `HELLO_WORLD` here or we'll get compiler errors. (Rust also supports type infering, but it looks like `const` always requires an [explicit type annotation](http://rustbyexample.com/custom_types/constants.html). Maybe this [could change in the future](https://users.rust-lang.org/t/when-i-export-a-str-as-const-why-do-i-need-to-set-its-type-and-lifetime/6112/2) for cases like this one.) [As noted earlier](../hello-world/README.md) `"Hello world!"` is called a _string literal_. Its type is `&str` (spoken as _string slice_). Rust actually has another String type called just `String`. A `&str` has a fixed size and cannot be mutated while a `String` is heap-allocated and has a dynamic size. A `&str` can be easily converted to a `String` with the `to_string` method like this: `"Hello world!".to_string();`. We'll see more of that in later examples.
 
 But what is the meaning behind `'static`? This is a so called [_lifetime_](https://doc.rust-lang.org/book/lifetimes.html) - a concept which is very unique to Rust and one of its big advantages. But because it is so unique and new it is probably also the biggest hurdle while learning Rust. Together with the concept of [_borrowing_](https://doc.rust-lang.org/book/references-and-borrowing.html) it forms a feature called [_ownership_](https://doc.rust-lang.org/book/ownership.html). Ownership is Rust's way to guarantee memory safety without introducing a garbage collector. This is done at compile time, not runtime and the part in the compiler which does this check is called _borrow checker_. A lifetime tells the compiler how long a resource _lives_. That means how long this resource is available in memory. For now I like to thing about lifetimes as _meta data_ associated to a variable or constant very much like a type (e.g. `&str`). Thanks to type infering we don't need to add types for every variable and the same is true for lifetimes. Sometimes we need to tell the compiler a lifetime and sometimes not. This is probably not a fully satisfying answer and you have questions, but we'll explore _ownership_, _lifetimes_ and _borrowing_ in more detail in future examples. Just one last explanation: `'static` is actually a special lifetime (and the _only_ special lifetime which exists). It says that the resource has the [lifetime of the entire program](https://doc.rust-lang.org/book/lifetimes.html#static). Note that string literals like `"Hello world!"` _always_ have a lifetime of `'static`.
 
@@ -377,7 +377,7 @@ $ npm start
 Required "Hello world!".
 ```
 
-Good. Now we switch to Rust. As I said in our [setup](../setup) `$ cargo install` actually installs only _globally_ and only crates which should be used as a command line tool. Think about the times you installed something like `$ npm install -g gulp-cli`. If `gulp` would exist in Cargo we would install it pretty much this way: `$ cargo install gulp`.
+Good. Now we switch to Rust. As I said in our [setup](../setup/README.md) `$ cargo install` actually installs only _globally_ and only crates which should be used as a command line tool. Think about the times you installed something like `$ npm install -g gulp-cli`. If `gulp` would exist in Cargo we would install it pretty much this way: `$ cargo install gulp`.
 
 However the crate we created earlier isn't a command line tool, but a library. We can't add it to our project via the command line. At least not with `cargo install` - in the future Cargo will probably support a [`cargo add`](https://github.com/rust-lang/cargo/issues/4#issuecomment-187241132) to do so. Currently we need to add it to our `Cargo.toml` manually in a section called `[dependencies]`. It looks like this:
 
@@ -439,4 +439,4 @@ It works! :tada:
 
 ______
 
-← [prev](../setup) | [next](../read-files) →
+← [prev](../setup/README.md) | [next](../read-files/README.md) →

--- a/parse-json/README.md
+++ b/parse-json/README.md
@@ -4,7 +4,7 @@
 
 In our last example we made an HTTPS request against the GitHub API with Node and Rust. That worked fine, but we got back a raw string as JSON. Not very usefull. This time we'll learn how to parse the JSON and extract the information we need. For this example we'll request the repositories of a specific GitHub user and we'll log the name and description of the repository and if it was forked.
 
-Our [Node example](../http-requests) doesn't need to change much to achieve that:
+Our [Node example](../http-requests/README.md) doesn't need to change much to achieve that:
 
 ```diff
 import { get } from 'https';
@@ -93,7 +93,7 @@ hyper = "0.9"
 +serde_json = "0.8"
 ```
 
-Sadly there is one more step involved to parse JSON with `serde`. We need to switch to a nightly build of Rust. At least for now. I'll tell you in a minute why. Just install nightly with [`rustup`](../setup).
+Sadly there is one more step involved to parse JSON with `serde`. We need to switch to a nightly build of Rust. At least for now. I'll tell you in a minute why. Just install nightly with [`rustup`](../setup/README.md).
 
 ```bash
 $ rustup install nightly
@@ -126,7 +126,7 @@ We can pass additional data to attributes (`#[inline(always)]`) or keys and valu
 
 For now _every_ attribute is defined by the Rust compiler and we want to use an attribute called `derive` which is only available in nightlies. `derive` allows us to automatically implement certain traits for a custom struct. The trait we're interested in is [`Deserialize`](https://docs.serde.rs/serde/de/trait.Deserialize.html) from... you guessed it: `serde`!
 
-Let us look at modified [Rust example](../http-requests) :
+Let us look at modified [Rust example](../http-requests/README.md) :
 
 ```diff
 +#![feature(custom_derive, plugin)]
@@ -240,4 +240,4 @@ I guess as a JavaScript developers you just need to get comfortable to move more
 
 ______
 
-← [prev](../http-requests)
+← [prev](../http-requests/README.md)

--- a/read-files/README.md
+++ b/read-files/README.md
@@ -246,7 +246,7 @@ match file.read(&mut buffer) {
 };
 ```
 
-We pass `buffer` to `file.read` with `&mut`. That means that `buffer` is passed to `file.read` as a _mutable reference_. This is needed to _allow_ `file.read` to change `buffer`. (It is not enough to flag `buffer` as `mut` in general, we need to allow this to other functions or method in every case, where it is intended.) _Allowing_ this is actually a core feature of Rust called _ownership_. I mentioned that [earlier](../package-manager) and we'll see it in a lot of examples, because it is such an essential feature to Rust. `file.read` _borrows_ `buffer` for as long as `file.read` _runs_. If it quits our `main` function becomes the owner of `buffer` again. Doing so ensures that only _one_ function is the owner of a piece of memory at a time and prevents data races. This makes Rust so safe.
+We pass `buffer` to `file.read` with `&mut`. That means that `buffer` is passed to `file.read` as a _mutable reference_. This is needed to _allow_ `file.read` to change `buffer`. (It is not enough to flag `buffer` as `mut` in general, we need to allow this to other functions or method in every case, where it is intended.) _Allowing_ this is actually a core feature of Rust called _ownership_. I mentioned that [earlier](../package-manager/README.md) and we'll see it in a lot of examples, because it is such an essential feature to Rust. `file.read` _borrows_ `buffer` for as long as `file.read` _runs_. If it quits our `main` function becomes the owner of `buffer` again. Doing so ensures that only _one_ function is the owner of a piece of memory at a time and prevents data races. This makes Rust so safe.
 
 `file.read` has no return value which we are interested in, so we do nothing in the `Ok` case (just `Ok(_) => ()` which is kind of a [_noop_](https://en.wikipedia.org/wiki/NOP)).
 
@@ -296,4 +296,4 @@ We could simplify our example even more with less verbose error handling, but I'
 
 ______
 
-← [prev](../package-manager) | [next](../write-files) →
+← [prev](../package-manager/README.md) | [next](../write-files/README.md) →

--- a/setup/README.md
+++ b/setup/README.md
@@ -152,7 +152,7 @@ On the following site you can choose between stable and insider releases. The in
 
 Now we will install [Rusty Code](https://github.com/saviorisdead/RustyCode) the Rust extension for VS Code. Just open VS Code, press `⌘P` (Quick Open) and type `ext install RustyCode`. Click on _Rusty Code_.
 
-After that we need to install [Racer](https://github.com/phildawes/racer). This is used by Rusty Code to get code completion for Rust. You can install Racer easily with Rusts package manager called Cargo, which was installed alongside with Rust. I'll introduce you to Cargo in more detail in the chapter about [package manager](../package-manager). For now you can install Racer with the following command:
+After that we need to install [Racer](https://github.com/phildawes/racer). This is used by Rusty Code to get code completion for Rust. You can install Racer easily with Rusts package manager called Cargo, which was installed alongside with Rust. I'll introduce you to Cargo in more detail in the chapter about [package manager](../package-manager/README.md). For now you can install Racer with the following command:
 
 ```bash
 $ cargo install racer
@@ -191,4 +191,4 @@ Last but not least you'll want to install the [TOML extension](https://marketpla
 
 ______
 
-[next](../hello-world) →
+[next](../hello-world/README.md) →

--- a/write-files/README.md
+++ b/write-files/README.md
@@ -2,7 +2,7 @@
 
 ## Node
 
-In our [last example](../read-files) we used `readFile` to read the content of a file and switched to a combination of `openSync` and `readSync` to achieve the same goal in a low-level manner and synchronous way to make it easier comparable to Rust. Now we switch to `readFileSync` to keep things easier. We reuse our basic project structure with typings for this.
+In our [last example](../read-files/README.md) we used `readFile` to read the content of a file and switched to a combination of `openSync` and `readSync` to achieve the same goal in a low-level manner and synchronous way to make it easier comparable to Rust. Now we switch to `readFileSync` to keep things easier. We reuse our basic project structure with typings for this.
 
 In this example we want to read two files: `hello.txt` and `world.txt`. They contain just a single word - `Hello` and `world`. We concatenate the content of both files and write it into a new file `hello-world.txt`. Its contain should be `Hello world!` at the end. (The ` ` and the `!` will be added by us.)
 
@@ -178,7 +178,7 @@ Content is: world
 
 Fine. Now we can look into different ways of handling errors in Rust before we'll add the actual part of writing files.
 
-The patterns we used for now was using `panic!` which allows adding a custom error message and exits our program. This is okay, but a little bit verbose. The shortest way for error handling is calling `unwrap()` on functions returning a `Result`. (Remember from the [last example](../read-files) that the `Result` type has an `Err` case and an `Ok` case which we both _need_ to handle. This can be done with pattern matching like we did for now.) `unwrap` _just_ exits the program on `Err` or returns the result on `Ok`, but you cannot pass a custom error message. It looks like that.
+The patterns we used for now was using `panic!` which allows adding a custom error message and exits our program. This is okay, but a little bit verbose. The shortest way for error handling is calling `unwrap()` on functions returning a `Result`. (Remember from the [last example](../read-files/README.md) that the `Result` type has an `Err` case and an `Ok` case which we both _need_ to handle. This can be done with pattern matching like we did for now.) `unwrap` _just_ exits the program on `Err` or returns the result on `Ok`, but you cannot pass a custom error message. It looks like that.
 
 ```diff
 -use std::error::Error;
@@ -438,4 +438,4 @@ Awesome! In this example your learned different error handling patterns, differe
 
 ______
 
-← [prev](../read-files) | [next](../http-requests) →
+← [prev](../read-files/README.md) | [next](../http-requests/README.md) →


### PR DESCRIPTION
I was reading through this in the mobile view and when clicking a "next" link it just shows the directory requiring an extra click to get to the content. This way both mobile and desktop sites will show the readme in a full page view when navigating.